### PR TITLE
Let "GetPrivateProfileString" use Unicode to prevent mojibake issue…

### DIFF
--- a/wumgr/Program.cs
+++ b/wumgr/Program.cs
@@ -263,7 +263,7 @@ namespace wumgr
             WritePrivateProfileString(Section, Key, Value, INIPath != null ? INIPath : GetINIPath());
         }
 
-        [DllImport("kernel32")]
+        [DllImport("kernel32", CharSet = CharSet.Unicode)]
         private static extern int GetPrivateProfileString(string section, string key, string def, [In, Out] char[] retVal, int size, string filePath);
         public static string IniReadValue(string Section, string Key, string Default = "", string INIPath = null)
         {


### PR DESCRIPTION
… when specified "Language" is different from system locale (non-Unicode language)

![1](https://user-images.githubusercontent.com/3296077/105640422-f9085b80-5eb8-11eb-9d0d-cf9c80a19081.png)
![2](https://user-images.githubusercontent.com/3296077/105640425-fad21f00-5eb8-11eb-8103-6ff207f2aca7.png)
![3](https://user-images.githubusercontent.com/3296077/105640427-fb6ab580-5eb8-11eb-8b1f-b7e4002fd9d0.png)
